### PR TITLE
meson.build: generate pkg-config file for liblfi

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -114,4 +114,12 @@ if get_option('enable_linux')
     dependencies: lfi_linux.as_link_whole(),
     install: true,
   )
+
+  pkg = import('pkgconfig')
+  pkg.generate(
+      name: 'lfi',
+      filebase: 'lfi',
+      description: 'LFI runtime',
+      libraries: [liblfi_so, liblfi_a],
+  )
 endif


### PR DESCRIPTION
Generates a `pkg-config` that build systems can use to build programs using `liblfi`.
