### PR TITLE
subprojects: pin non-LFI subprojects to specific git revisions

### DIFF
--- a/subprojects/argp.wrap
+++ b/subprojects/argp.wrap
@@ -1,5 +1,5 @@
 [wrap-git]
 url = https://github.com/argp-standalone/argp-standalone
-revision = head
+revision = 8ded2bc942740b5d291e450af661c5090dc3ca38
 directory = libargp
 patch_directory = libargp


### PR DESCRIPTION
This allows building LFI in sandboxed environments like Nix, and
provides assurance that a specific LFI revision will not silently
break or diverge due to updates of its underlying dependencies (ones
that are not part of the LFI project).
