### PR TITLE
feat: Implement signal delivery for x64/arm64 sandbox

### DIFF
--- a/core/arch/arm64/runtime.S
+++ b/core/arch/arm64/runtime.S
@@ -27,7 +27,7 @@ lfi_ctx_entry:
     mov x8, sp
     str x8, [x1]
     // put entrypoint in x30
-    mov x30, x2
+    mov x28, x2
 
 #ifndef CTXREG
     // set the sandbox thread control block by saving the old value of
@@ -52,8 +52,8 @@ lfi_ctx_entry:
     ldp x22, x23, [x0, REGS_X(22)]
     ldp x24, x25, [x0, REGS_X(24)]
     ldp x26, x27, [x0, REGS_X(26)]
-    ldp x28, x29, [x0, REGS_X(28)]
-    ldp xzr, x1,  [x0, REGS_X(30)]
+    ldp xzr, x29, [x0, REGS_X(28)]
+    ldp x30, x1,  [x0, REGS_X(30)]
     mov sp, x1
     ldp x0, x1, [x0, REGS_X(0)]
     // zero vector registers
@@ -92,9 +92,11 @@ lfi_ctx_entry:
     // zero integer and fp flags
     ands xzr, xzr, xzr
     msr fpsr, xzr
-    // NOTE: x30 must contain a valid sandbox address
+    // NOTE: x28 and x30 must contain a valid sandbox address
+    // Entry with ret is not compatible with restorer, DO NOT overwrite x30
     add x30, REG_BASE, w30, uxtw
-    ret
+    add x28, REG_BASE, w28, uxtw
+    br x28
 
 // lfi_ctx_end(struct LFIContext *ctx, int val)
 .global lfi_ctx_end

--- a/core/ctx.c
+++ b/core/ctx.c
@@ -38,10 +38,17 @@ lfi_ctx_data(struct LFIContext *ctx)
 EXPORT int
 lfi_ctx_run(struct LFIContext *ctx, uintptr_t entry)
 {
+    // Save and restore invoke_info.ctx so that nested calls (e.g. running a
+    // signal handler while sandbox execution is still live on this thread)
+    // leave the outer ctx intact.
+    struct LFIContext **saved_ctxp = lfi_invoke_info.ctx;
+
     // Save the ctx in invoke info so it can be retrieved via lfi_cur_ctx.
     lfi_invoke_info.ctx = &ctx;
     // Enter the sandbox, saving the stack pointer to host_sp.
     int ret = lfi_ctx_entry(ctx, (uintptr_t *) &ctx->regs.host_sp, entry);
+
+    lfi_invoke_info.ctx = saved_ctxp;
     return ret;
 }
 

--- a/linux/arch/arm64/arch_sys.h
+++ b/linux/arch/arm64/arch_sys.h
@@ -2,6 +2,8 @@
 
 #include "lfi_core.h"
 
+#include <signal.h>
+
 #define LINUX_SYS_io_setup                0
 #define LINUX_SYS_io_destroy              1
 #define LINUX_SYS_io_submit               2
@@ -314,3 +316,7 @@
 
 void
 arch_syshandle(struct LFIContext *ctx);
+
+bool
+arch_forward_signal(struct LFIContext *ctx, int sig, siginfo_t *si,
+    void *ucontext);

--- a/linux/arch/arm64/arch_types.h
+++ b/linux/arch/arm64/arch_types.h
@@ -36,3 +36,13 @@ struct Stat {
     struct TimeSpec st_ctim;
     uint32_t _unused[2];
 };
+
+struct SigAction {
+    uintptr_t handler;
+    unsigned long flags;
+    uintptr_t restorer;
+    uint64_t mask;
+};
+
+#define SA_RESTORER 0x04000000
+

--- a/linux/arch/arm64/arch_types.h
+++ b/linux/arch/arm64/arch_types.h
@@ -46,3 +46,90 @@ struct SigAction {
 
 #define SA_RESTORER 0x04000000
 
+struct SigInfo {
+    uint8_t signo[4];
+    uint8_t errno_[4];
+    uint8_t code[4];
+    uint8_t pad1_[4];
+    union {
+        struct {
+            union {
+                struct {
+                    // signals sent by kill() and sigqueue() set these
+                    uint8_t pid[4];
+                    uint8_t uid[4];
+                };
+                struct {
+                    // SIGALRM sets these
+                    uint8_t timerid[4];
+                    uint8_t overrun[4];
+                };
+            };
+            union {
+                uint8_t value[8]; // provided by third arg of sigqueue(2)
+                struct {
+                    uint8_t status[4];
+                    uint8_t pad2_[4];
+                    uint8_t utime[8];
+                    uint8_t stime[8];
+                };
+            };
+        };
+        struct {
+            // SIGILL, SIGFPE, SIGSEGV, SIGBUS, SIGTRAP
+            uint8_t addr[8];
+            uint8_t addr_lsb[2];
+            uint8_t pad3_[6];
+            union {
+                struct {
+                    uint8_t lower[8];
+                    uint8_t upper[8];
+                };
+                uint8_t pkey[4];
+            };
+        };
+        struct {
+            uint8_t band[8]; // SIGPOLL
+            uint8_t fd[4];
+        };
+        struct {
+            uint8_t call_addr[8];
+            uint8_t syscall[4];
+            uint8_t arch[4];
+        };
+        uint8_t payload[112];
+    };
+};
+
+struct UContext {
+    uint8_t uc__flags[8];
+    uint8_t uc__link[8];
+
+    // stack_t
+    uint8_t ss__sp[8];
+    uint8_t ss__flags[4];
+    uint8_t pad0_[4];
+    uint8_t ss_size[8];
+
+    // glibc uses a 1024-bit sigset
+    uint8_t sigmask[8];
+    uint8_t __sigmask[120];
+
+    uint8_t pad2_[8];
+    // sigcontext
+    uint8_t fault_address[8];
+    uint8_t regs[31][8];
+    uint8_t sp[8];
+    uint8_t pc[8];
+    uint8_t pstate[8];
+
+    uint8_t pad3_[8];
+    uint8_t __reserved[4096]; // TODO aligned 16 static assert
+};
+
+// TODO: FPSIMD context
+
+struct SigFrame {
+    struct SigInfo si;
+    struct UContext uc;
+};

--- a/linux/arch/arm64/sys.c
+++ b/linux/arch/arm64/sys.c
@@ -17,3 +17,10 @@ arch_syshandle(struct LFIContext *ctx)
     regs->x0 = syshandle(t, regs->x8, regs->x0, regs->x1, regs->x2, regs->x3,
         regs->x4, regs->x5);
 }
+
+bool
+arch_forward_signal(struct LFIContext *ctx, int sig, siginfo_t *si,
+    void *ucontext)
+{
+    assert(!"unimplemented");
+}

--- a/linux/arch/arm64/sys.c
+++ b/linux/arch/arm64/sys.c
@@ -5,8 +5,32 @@
 #include "lfi_core.h"
 #include "linux.h"
 #include "proc.h"
+#include "lock.h"
 
 #include <assert.h>
+#include <sys/ucontext.h>
+
+#define ROUNDDOWN(X, K) ((X) & -(K))
+
+static void
+put32(uint8_t *p, uint32_t v)
+{
+    __builtin_memcpy(p, &v, 4);
+}
+
+static void
+put64(uint8_t *p, uint64_t v)
+{
+    __builtin_memcpy(p, &v, 8);
+}
+
+static uint64_t
+read64(uint8_t *p)
+{
+    uint64_t v;
+    __builtin_memcpy(&v, p, 8);
+    return v;
+}
 
 void
 arch_syshandle(struct LFIContext *ctx)
@@ -23,8 +47,128 @@ bool
 arch_forward_signal(struct LFIContext *ctx, int sig, siginfo_t *si,
     void *ucontext)
 {
+    if (!ctx)
+        return false;
     struct LFILinuxThread *t = lfi_ctx_data(ctx);
-    assert(t && t->proc);
-    LOG(t->proc->engine, "warning: signal forwarding is not supported in this architecture");
-    return false;
+    if (!t || !t->proc)
+        return false;
+    if (sig < 1 || sig >= LINUX_NSIG)
+        return false;
+
+    {
+        LOCK_WITH_DEFER(&t->proc->lk_signals, lk_signals);
+        if (!t->proc->signals[sig].valid)
+            return false;
+    }
+
+    // NOTE: before adding support for other signals, their host sighandler must be
+    // registered.
+    assert(sig == LINUX_SIGSEGV || sig == LINUX_SIGILL || sig == LINUX_SIGBUS);
+
+    struct SigAction sighand = t->proc->signals[sig].entry;
+
+    struct SigFrame sf = {0};
+
+    ucontext_t *uctx = (ucontext_t *)ucontext;
+
+    // Fill SigInfo.
+    put32(sf.si.signo, sig);
+    put32(sf.si.code, si->si_code);
+    if (sig == LINUX_SIGILL || sig == LINUX_SIGFPE || sig == LINUX_SIGSEGV ||
+        sig == LINUX_SIGBUS || sig == LINUX_SIGTRAP) {
+        put64(sf.si.addr, (uintptr_t)si->si_addr);
+    }
+
+    put64(sf.uc.fault_address, uctx->uc_mcontext.fault_address);
+    __builtin_memcpy(sf.uc.regs, uctx->uc_mcontext.regs, sizeof(sf.uc.regs));
+    put64(sf.uc.sp, uctx->uc_mcontext.sp);
+    put64(sf.uc.pc, uctx->uc_mcontext.pc);
+    put64(sf.uc.pstate, uctx->uc_mcontext.pstate);
+    // TODO: __reserved for fpsimd, esr, sve
+
+    uintptr_t sp = ROUNDDOWN((uintptr_t)uctx->uc_mcontext.sp, 16);
+    sp -= sizeof(sf);
+    if (!lfi_box_ptrvalid(t->proc->box, sp)) {
+        ERROR("%s: signal handler may access memory outside sandbox region.!\n", __PRETTY_FUNCTION__);
+        return false;
+    }
+
+    lfi_box_copyto(t->proc->box, sp, &sf, sizeof(sf));
+
+    // Set up sandbox registers for handler invocation.
+    struct LFIRegs *regs = lfi_ctx_regs(ctx);
+    regs->sp = sp;
+    regs->x0 = sig;
+    regs->x1 = sp + offsetof(struct SigFrame, si);
+    regs->x2 = sp + offsetof(struct SigFrame, uc);
+    regs->x30 = sighand.restorer; // SAFETY: lfiptr_t restorer
+
+    uintptr_t saved_host_sp = regs->host_sp;
+
+    // Run the sandbox signal handler. Returns when the handler calls
+    // rt_sigreturn, which invokes lfi_ctx_exit. siglongjmp is not supported.
+    lfi_ctx_run(ctx, sighand.handler);
+
+    regs->host_sp = saved_host_sp;
+
+    // before signal frame re-read
+    uintptr_t old_requested_pc = read64(sf.uc.pc);
+
+    uintptr_t frame_sp = lfi_ctx_regs(ctx)->sp;
+    lfi_box_copyfm(t->proc->box, &sf, frame_sp, sizeof(sf));
+
+    // Validate RIP the handler wants the sandbox context to resume at.
+    uintptr_t requested_pc = read64(sf.uc.pc);
+    if (!lfi_box_ptrvalid(t->proc->box, requested_pc)) {
+        ERROR("%s: requested pc is invalid!\n", __PRETTY_FUNCTION__);
+        return false;
+    }
+    if (old_requested_pc == requested_pc) {
+        // resume at the faulting instruction, possibly unaligned
+        LOG(t->proc->engine, "%s: returning to the faulting pc!\n", __PRETTY_FUNCTION__);
+    }
+
+    // Tell the kernel to resume sandbox execution at the validated RIP.
+    uctx->uc_mcontext.pc = requested_pc;
+
+    // SAFETY: X30 must be validated.
+    uintptr_t x30 = uctx->uc_mcontext.regs[30];
+    if (!lfi_box_ptrvalid(t->proc->box, x30)) {
+        ERROR("%s: x30 points to host memory!\n", __PRETTY_FUNCTION__);
+        return false;
+    }
+    regs->x30 = x30;
+
+    regs->x0 = uctx->uc_mcontext.regs[0];
+    regs->x1 = uctx->uc_mcontext.regs[1];
+    regs->x2 = uctx->uc_mcontext.regs[2];
+    regs->x3 = uctx->uc_mcontext.regs[3];
+    regs->x4 = uctx->uc_mcontext.regs[4];
+    regs->x5 = uctx->uc_mcontext.regs[5];
+    regs->x6 = uctx->uc_mcontext.regs[6];
+    regs->x7 = uctx->uc_mcontext.regs[7];
+    regs->x8 = uctx->uc_mcontext.regs[8];
+    regs->x9 = uctx->uc_mcontext.regs[9];
+    regs->x10 = uctx->uc_mcontext.regs[10];
+    regs->x11 = uctx->uc_mcontext.regs[11];
+    regs->x12 = uctx->uc_mcontext.regs[12];
+    regs->x13 = uctx->uc_mcontext.regs[13];
+    regs->x14 = uctx->uc_mcontext.regs[14];
+    regs->x15 = uctx->uc_mcontext.regs[15];
+    regs->x16 = uctx->uc_mcontext.regs[16];
+    regs->x17 = uctx->uc_mcontext.regs[17];
+    regs->x18 = uctx->uc_mcontext.regs[18];
+    regs->x19 = uctx->uc_mcontext.regs[19];
+    regs->x20 = uctx->uc_mcontext.regs[20];
+    regs->x21 = uctx->uc_mcontext.regs[21];
+    regs->x22 = uctx->uc_mcontext.regs[22];
+    regs->x23 = uctx->uc_mcontext.regs[23];
+    regs->x24 = uctx->uc_mcontext.regs[24];
+    regs->x25 = uctx->uc_mcontext.regs[25];
+    regs->x26 = uctx->uc_mcontext.regs[26];
+    regs->x27 = uctx->uc_mcontext.regs[27];
+    regs->x28 = uctx->uc_mcontext.regs[28];
+    regs->x29 = uctx->uc_mcontext.regs[29];
+
+    return true;
 }

--- a/linux/arch/arm64/sys.c
+++ b/linux/arch/arm64/sys.c
@@ -2,6 +2,7 @@
 
 #include "arch_sys.h"
 #include "lfi_arch.h"
+#include "lfi_core.h"
 #include "linux.h"
 #include "proc.h"
 
@@ -22,5 +23,8 @@ bool
 arch_forward_signal(struct LFIContext *ctx, int sig, siginfo_t *si,
     void *ucontext)
 {
-    assert(!"unimplemented");
+    struct LFILinuxThread *t = lfi_ctx_data(ctx);
+    assert(t && t->proc);
+    LOG(t->proc->engine, "warning: signal forwarding is not supported in this architecture");
+    return false;
 }

--- a/linux/arch/x64/arch_sys.h
+++ b/linux/arch/x64/arch_sys.h
@@ -2,6 +2,8 @@
 
 #include "lfi_core.h"
 
+#include <signal.h>
+
 #define LINUX_SYS_read              0
 #define LINUX_SYS_write             1
 #define LINUX_SYS_open              2
@@ -97,3 +99,7 @@
 
 void
 arch_syshandle(struct LFIContext *ctx);
+
+bool
+arch_forward_signal(struct LFIContext *ctx, int sig, siginfo_t *si,
+    void *ucontext);

--- a/linux/arch/x64/arch_types.h
+++ b/linux/arch/x64/arch_types.h
@@ -36,3 +36,133 @@ struct Stat {
     struct TimeSpec st_ctim;
     uint64_t _unused[3];
 };
+
+struct SigAction {
+    uintptr_t handler;
+    unsigned long flags;
+    uintptr_t restorer;
+    uint64_t mask;
+};
+
+// These definitions are from jart/blink.
+
+struct SigInfo {
+    uint8_t signo[4];
+    uint8_t errno_[4];
+    uint8_t code[4];
+    uint8_t pad1_[4];
+    union {
+        struct {
+            union {
+                struct {
+                    // signals sent by kill() and sigqueue() set these
+                    uint8_t pid[4];
+                    uint8_t uid[4];
+                };
+                struct {
+                    // SIGALRM sets these
+                    uint8_t timerid[4];
+                    uint8_t overrun[4];
+                };
+            };
+            union {
+                uint8_t value[8]; // provided by third arg of sigqueue(2)
+                struct {
+                    uint8_t status[4];
+                    uint8_t pad2_[4];
+                    uint8_t utime[8];
+                    uint8_t stime[8];
+                };
+            };
+        };
+        struct {
+            // SIGILL, SIGFPE, SIGSEGV, SIGBUS, SIGTRAP
+            uint8_t addr[8];
+            uint8_t addr_lsb[2];
+            uint8_t pad3_[6];
+            union {
+                struct {
+                    uint8_t lower[8];
+                    uint8_t upper[8];
+                };
+                uint8_t pkey[4];
+            };
+        };
+        struct {
+            uint8_t band[8]; // SIGPOLL
+            uint8_t fd[4];
+        };
+        struct {
+            uint8_t call_addr[8];
+            uint8_t syscall[4];
+            uint8_t arch[4];
+        };
+        uint8_t payload[112];
+    };
+};
+
+struct UContext {
+    uint8_t uc__flags[8];
+    uint8_t uc__link[8];
+
+    // stack_t (sigaltstack)
+    uint8_t ss__sp[8];
+    uint8_t ss__flags[4];
+    uint8_t pad0_[4];
+    uint8_t ss_size[8];
+
+    // sigcontext
+    uint8_t r8[8];
+    uint8_t r9[8];
+    uint8_t r10[8];
+    uint8_t r11[8];
+    uint8_t r12[8];
+    uint8_t r13[8];
+    uint8_t r14[8];
+    uint8_t r15[8];
+    uint8_t rdi[8];
+    uint8_t rsi[8];
+    uint8_t rbp[8];
+    uint8_t rbx[8];
+    uint8_t rdx[8];
+    uint8_t rax[8];
+    uint8_t rcx[8];
+    uint8_t rsp[8];
+    uint8_t rip[8];
+    uint8_t eflags[8];
+    uint8_t cs[2];
+    uint8_t gs[2];
+    uint8_t fs[2];
+    uint8_t ss[2];
+    uint8_t err[8];
+    uint8_t trapno[8];
+    uint8_t oldmask[8];
+    uint8_t cr2[8];
+    uint8_t fpstate[8];
+    uint8_t pad1_[64];
+
+    uint8_t sigmask[8];
+};
+
+struct FPState {
+    uint8_t cwd[2];
+    uint8_t swd[2];
+    uint8_t ftw[2];
+    uint8_t fop[2];
+    uint8_t rip[8];
+    uint8_t rdp[8];
+    uint8_t mxcsr[4];
+    uint8_t mxcr_mask[4];
+    uint8_t st[8][16];
+    uint8_t xmm[16][16];
+    uint8_t padding_[96];
+};
+
+#define SA_RESTORER 0x04000000
+
+struct SigFrame {
+    uint8_t ret[8];
+    struct SigInfo si;
+    struct UContext uc;
+    struct FPState fp;
+};

--- a/linux/arch/x64/sys.c
+++ b/linux/arch/x64/sys.c
@@ -1,11 +1,38 @@
+#define _GNU_SOURCE
 #include "sys.h"
 
 #include "arch_sys.h"
 #include "lfi_arch.h"
+#include "lfi_core.h"
 #include "linux.h"
 #include "proc.h"
 
 #include <assert.h>
+#include <sys/ucontext.h>
+
+#define ROUNDDOWN(X, K) ((X) & -(K))
+
+static const int kRedzoneSize = 128;
+
+static void
+put32(uint8_t *p, uint32_t v)
+{
+    __builtin_memcpy(p, &v, 4);
+}
+
+static void
+put64(uint8_t *p, uint64_t v)
+{
+    __builtin_memcpy(p, &v, 8);
+}
+
+static uint64_t
+read64(uint8_t *p)
+{
+    uint64_t v;
+    __builtin_memcpy(&v, p, 8);
+    return v;
+}
 
 void
 arch_syshandle(struct LFIContext *ctx)
@@ -18,4 +45,136 @@ arch_syshandle(struct LFIContext *ctx)
 
     regs->rax = syshandle(t, orig_rax, regs->rdi, regs->rsi, regs->rdx,
         regs->r10, regs->r8, regs->r9);
+}
+
+// Deliver a signal to the currently-running sandbox context on this thread.
+// Returns true if the signal was successfully delivered to a sandbox handler
+// and returned, false if it fails to handle the forwarded signal.
+bool
+arch_forward_signal(struct LFIContext *ctx, int sig, siginfo_t *si,
+    void *ucontext)
+{
+    if (!ctx)
+        return false;
+    struct LFILinuxThread *t = lfi_ctx_data(ctx);
+    if (!t || !t->proc)
+        return false;
+    if (sig < 1 || sig >= LINUX_NSIG)
+        return false;
+    if (!t->proc->signals[sig].valid)
+        return false;
+
+    // NOTE: before adding support for other signals, their host sighandler must be
+    // registered.
+    assert(sig == LINUX_SIGSEGV || sig == LINUX_SIGILL);
+
+    struct SigAction sighand = t->proc->signals[sig].entry;
+
+    struct SigFrame sf = {0};
+
+    ucontext_t *uctx = (ucontext_t *)ucontext;
+    greg_t *host_regs = uctx->uc_mcontext.gregs;
+
+    // Fill SigInfo.
+    put32(sf.si.signo, sig);
+    put32(sf.si.code, si->si_code);
+    if (sig == LINUX_SIGILL || sig == LINUX_SIGFPE || sig == LINUX_SIGSEGV ||
+        sig == LINUX_SIGBUS || sig == LINUX_SIGTRAP) {
+        put64(sf.si.addr, (uintptr_t)si->si_addr);
+    }
+
+    // Fill UContext from interrupted sandbox registers.
+    // TODO: sigmask, fpstate
+    put64(sf.uc.r8,     host_regs[REG_R8]);
+    put64(sf.uc.r9,     host_regs[REG_R9]);
+    put64(sf.uc.r10,    host_regs[REG_R10]);
+    put64(sf.uc.r11,    host_regs[REG_R11]);
+    put64(sf.uc.r12,    host_regs[REG_R12]);
+    put64(sf.uc.r13,    host_regs[REG_R13]);
+    put64(sf.uc.r14,    host_regs[REG_R14]);
+    put64(sf.uc.r15,    host_regs[REG_R15]);
+    put64(sf.uc.rdi,    host_regs[REG_RDI]);
+    put64(sf.uc.rsi,    host_regs[REG_RSI]);
+    put64(sf.uc.rbp,    host_regs[REG_RBP]);
+    put64(sf.uc.rbx,    host_regs[REG_RBX]);
+    put64(sf.uc.rdx,    host_regs[REG_RDX]);
+    put64(sf.uc.rax,    host_regs[REG_RAX]);
+    put64(sf.uc.rcx,    host_regs[REG_RCX]);
+    put64(sf.uc.rsp,    host_regs[REG_RSP]);
+    put64(sf.uc.rip,    host_regs[REG_RIP]);
+    put64(sf.uc.eflags, host_regs[REG_EFL]);
+
+    // Compute signal frame location: below redzone, 16-byte aligned, with the
+    // return address slot making rsp 8-mod-16 (x86-64 call convention).
+    uintptr_t sp = (uintptr_t)host_regs[REG_RSP];
+    sp -= kRedzoneSize; // skip redzone
+    sp = ROUNDDOWN(sp, 16);
+    sp -= sizeof(sf);
+    assert((sp & 15) == 8);
+
+    put64(sf.ret, sighand.restorer);
+    put64(sf.uc.fpstate, sp + offsetof(struct SigFrame, fp));
+
+    lfi_box_copyto(t->proc->box, sp, &sf, sizeof(sf));
+
+    // Set up sandbox registers for handler invocation.
+    struct LFIRegs *regs = lfi_ctx_regs(ctx);
+    regs->rsp = sp;
+    regs->rdi = sig;
+    regs->rsi = sp + offsetof(struct SigFrame, si);
+    regs->rdx = sp + offsetof(struct SigFrame, uc);
+
+    uintptr_t saved_host_sp = regs->host_sp;
+
+    // Run the sandbox signal handler. Returns when the handler calls
+    // rt_sigreturn, which invokes lfi_ctx_exit.
+    lfi_ctx_run(ctx, sighand.handler);
+
+    regs->host_sp = saved_host_sp;
+
+    // before signal frame re-read
+    uintptr_t old_requested_rip = read64(sf.uc.rip);
+
+    // After the handler's ret, rsp was incremented by 8 (ret popped the
+    // restorer address). Read back the (potentially modified) signal frame.
+    uintptr_t frame_sp = lfi_ctx_regs(ctx)->rsp - 8;
+    lfi_box_copyfm(t->proc->box, &sf, frame_sp, sizeof(sf));
+
+    // Validate RIP the handler wants the sandbox context to resume at.
+    uintptr_t requested_rip = read64(sf.uc.rip);
+    if (!lfi_box_ptrvalid(t->proc->box, requested_rip)) {
+        ERROR("%s: requested RIP is invalid!\n", __PRETTY_FUNCTION__);
+        return false;
+    }
+    if (old_requested_rip == requested_rip) {
+        // resume at the faulting instruction, possibly unaligned
+        LOG(t->proc->engine, "%s: returning to the faulting RIP!\n", __PRETTY_FUNCTION__);
+    } else if ((requested_rip & 0x1f) != 0) {
+        // RIP has changed by the sandbox, must aligned
+        ERROR("%s: requested RIP is not bundle aligned!\n", __PRETTY_FUNCTION__);
+        return false;
+    }
+
+    // Tell the kernel to resume sandbox execution at the validated RIP.
+    uctx->uc_mcontext.gregs[REG_RIP] = requested_rip;
+
+    // Restore sandbox context registers to pre-signal state for consistency.
+    regs->r8  = host_regs[REG_R8];
+    regs->r9  = host_regs[REG_R9];
+    regs->r10 = host_regs[REG_R10];
+    regs->r11 = host_regs[REG_R11];
+    regs->r12 = host_regs[REG_R12];
+    regs->r13 = host_regs[REG_R13];
+    regs->r14 = host_regs[REG_R14];
+    regs->r15 = host_regs[REG_R15];
+    regs->rdi = host_regs[REG_RDI];
+    regs->rsi = host_regs[REG_RSI];
+    regs->rbp = host_regs[REG_RBP];
+    regs->rbx = host_regs[REG_RBX];
+    regs->rdx = host_regs[REG_RDX];
+    regs->rax = host_regs[REG_RAX];
+    regs->rcx = host_regs[REG_RCX];
+    regs->rsp = host_regs[REG_RSP];
+
+    return true;
 }

--- a/linux/arch/x64/sys.c
+++ b/linux/arch/x64/sys.c
@@ -6,6 +6,7 @@
 #include "lfi_core.h"
 #include "linux.h"
 #include "proc.h"
+#include "lock.h"
 
 #include <assert.h>
 #include <sys/ucontext.h>
@@ -61,8 +62,12 @@ arch_forward_signal(struct LFIContext *ctx, int sig, siginfo_t *si,
         return false;
     if (sig < 1 || sig >= LINUX_NSIG)
         return false;
-    if (!t->proc->signals[sig].valid)
-        return false;
+
+    {
+        LOCK_WITH_DEFER(&t->proc->lk_signals, lk_signals);
+        if (!t->proc->signals[sig].valid)
+            return false;
+    }
 
     // NOTE: before adding support for other signals, their host sighandler must be
     // registered.
@@ -110,10 +115,15 @@ arch_forward_signal(struct LFIContext *ctx, int sig, siginfo_t *si,
     sp -= kRedzoneSize; // skip redzone
     sp = ROUNDDOWN(sp, 16);
     sp -= sizeof(sf);
+    if (!lfi_box_ptrvalid(t->proc->box, sp)) {
+        ERROR("%s: signal handler may access memory outside sandbox region.!\n", __PRETTY_FUNCTION__);
+        return false;
+    }
     assert((sp & 15) == 8);
 
     put64(sf.ret, sighand.restorer);
-    put64(sf.uc.fpstate, sp + offsetof(struct SigFrame, fp));
+    // TODO: zero until we support fpstate.
+    put64(sf.uc.fpstate, 0);
 
     lfi_box_copyto(t->proc->box, sp, &sf, sizeof(sf));
 
@@ -127,7 +137,7 @@ arch_forward_signal(struct LFIContext *ctx, int sig, siginfo_t *si,
     uintptr_t saved_host_sp = regs->host_sp;
 
     // Run the sandbox signal handler. Returns when the handler calls
-    // rt_sigreturn, which invokes lfi_ctx_exit.
+    // rt_sigreturn, which invokes lfi_ctx_exit. siglongjmp is not supported.
     lfi_ctx_run(ctx, sighand.handler);
 
     regs->host_sp = saved_host_sp;

--- a/linux/linux.c
+++ b/linux/linux.c
@@ -3,9 +3,75 @@
 #include "arch_sys.h"
 #include "cwalk.h"
 
+#include <signal.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <assert.h>
+
+struct sigaction oldact_sigsegv;
+struct sigaction oldact_sigill;
+struct sigaction oldact_sigbus;
+
+static void
+lfi_linux_on_signal(int sig, siginfo_t *si, void *ucontext) {
+    struct sigaction *oldactp;
+
+    switch (sig) {
+        case LINUX_SIGSEGV:
+            oldactp = &oldact_sigsegv;
+            break;
+        case LINUX_SIGILL:
+            oldactp = &oldact_sigill;
+            break;
+        case LINUX_SIGBUS:
+            oldactp = &oldact_sigbus;
+            break;
+        default:
+            ERROR("signal handling error: unsupported signal (%d) encountered\n", sig);
+            __builtin_unreachable();
+    }
+
+    if (!arch_forward_signal(lfi_cur_ctx(), sig, si, ucontext)) {
+        if (oldactp->sa_flags & SA_SIGINFO) {
+            oldactp->sa_sigaction(sig, si, ucontext);
+        } else if (oldactp->sa_handler == SIG_DFL || oldactp->sa_handler == SIG_IGN) {
+            sigaction(sig, oldactp, NULL);
+            // sandbox will execute the faulting instruction again.
+            // NOTE: will not be true for asynchronous signals
+        } else {
+            oldactp->sa_handler(sig);
+        }
+    }
+}
+
+// NOTE: is there any need for a per-signal register API?
+// NOTE: calling this more than once will clobber the oldact.
+static void
+lfi_linux_register_sighandler(struct LFILinuxEngine *engine)
+{
+    struct sigaction act;
+
+    // NOTE: Do I need SA_NODEFER ?
+    act.sa_flags = SA_SIGINFO | SA_ONSTACK;
+    act.sa_sigaction = lfi_linux_on_signal;
+    sigemptyset(&act.sa_mask);
+
+    if (sigaction(SIGSEGV, &act, &oldact_sigsegv))
+        perror("sigaction");
+    if (oldact_sigsegv.sa_handler != SIG_DFL)
+        LOG(engine, "warning: existing host handler for SIGSEGV is non-default and overwritten\n");
+
+    if (sigaction(SIGILL, &act, &oldact_sigill))
+        perror("sigaction");
+    if (oldact_sigill.sa_handler != SIG_DFL)
+        LOG(engine, "warning: existing host handler for SIGILL is non-default and overwritten\n");
+
+    if (sigaction(SIGBUS, &act, &oldact_sigbus))
+        perror("sigaction");
+    if (oldact_sigill.sa_handler != SIG_DFL)
+        LOG(engine, "warning: existing host handler for SIGBUS is non-default and overwritten\n");
+}
 
 EXPORT struct LFILinuxEngine *
 lfi_linux_new(struct LFIEngine *lfi_engine, struct LFILinuxOptions opts)
@@ -32,6 +98,8 @@ lfi_linux_new(struct LFIEngine *lfi_engine, struct LFILinuxOptions opts)
         .engine = lfi_engine,
         .opts = opts,
     };
+
+    lfi_linux_register_sighandler(engine);
 
     LOG(engine, "initialized LFI Linux engine");
 

--- a/linux/linux.c
+++ b/linux/linux.c
@@ -1,4 +1,5 @@
 #include "linux.h"
+#include "proc.h"
 
 #include "arch_sys.h"
 #include "cwalk.h"
@@ -9,39 +10,53 @@
 #include <unistd.h>
 #include <assert.h>
 
-struct sigaction oldact_sigsegv;
-struct sigaction oldact_sigill;
-struct sigaction oldact_sigbus;
+#ifndef SYS_MINIMAL
+static inline struct sigaction*
+get_engine_sigaction(struct LFIContext *ctx, int sig) {
+    if (!ctx)
+        return NULL;
+
+    struct LFILinuxThread *t = lfi_ctx_data(ctx);
+    if (!t || !t->proc || !t->proc->engine)
+        return NULL;
+
+    struct LFILinuxEngine *engine = t->proc->engine;
+    switch (sig) {
+        case LINUX_SIGSEGV: return &engine->oldact_sigsegv;
+        case LINUX_SIGILL:  return &engine->oldact_sigill;
+        case LINUX_SIGBUS:  return &engine->oldact_sigbus;
+        default:
+            ERROR("error: unsupported signal (%d) encountered\n", sig);
+            __builtin_unreachable();
+    }
+}
 
 static void
 lfi_linux_on_signal(int sig, siginfo_t *si, void *ucontext) {
-    struct sigaction *oldactp;
-
-    switch (sig) {
-        case LINUX_SIGSEGV:
-            oldactp = &oldact_sigsegv;
-            break;
-        case LINUX_SIGILL:
-            oldactp = &oldact_sigill;
-            break;
-        case LINUX_SIGBUS:
-            oldactp = &oldact_sigbus;
-            break;
-        default:
-            ERROR("signal handling error: unsupported signal (%d) encountered\n", sig);
-            __builtin_unreachable();
+    // First, try forwarding to sandbox
+    // Note: arch_forward_signal MUST be safe to call even if the engine is inconsistent.
+    if (lfi_invoke_info.ctx && arch_forward_signal(lfi_cur_ctx(), sig, si, ucontext)) {
+        return;
     }
 
-    if (!arch_forward_signal(lfi_cur_ctx(), sig, si, ucontext)) {
-        if (oldactp->sa_flags & SA_SIGINFO) {
-            oldactp->sa_sigaction(sig, si, ucontext);
-        } else if (oldactp->sa_handler == SIG_DFL || oldactp->sa_handler == SIG_IGN) {
-            sigaction(sig, oldactp, NULL);
-            // sandbox will execute the faulting instruction again.
-            // NOTE: will not be true for asynchronous signals
-        } else {
-            oldactp->sa_handler(sig);
-        }
+    // Fallback: Sandbox rejected it or isn't running, fetch host handler
+    struct sigaction *oldactp = get_engine_sigaction(lfi_cur_ctx(), sig);
+
+    if (!oldactp) {
+        struct sigaction dfl_act = { .sa_handler = SIG_DFL };
+        sigaction(sig, &dfl_act, NULL);
+        return;
+    }
+
+    // Invoke the host sigaction
+    if (oldactp->sa_flags & SA_SIGINFO) {
+        oldactp->sa_sigaction(sig, si, ucontext);
+    } else if (oldactp->sa_handler == SIG_DFL || oldactp->sa_handler == SIG_IGN) {
+        sigaction(sig, oldactp, NULL);
+        // sandbox will execute the faulting instruction again.
+        // NOTE: will not be true for asynchronous signals
+    } else {
+        oldactp->sa_handler(sig);
     }
 }
 
@@ -50,28 +65,30 @@ lfi_linux_on_signal(int sig, siginfo_t *si, void *ucontext) {
 static void
 lfi_linux_register_sighandler(struct LFILinuxEngine *engine)
 {
-    struct sigaction act;
+    struct sigaction act = {0};
 
-    // NOTE: Do I need SA_NODEFER ?
-    act.sa_flags = SA_SIGINFO | SA_ONSTACK;
+    // NOTE: SA_NODEFER to handle a signal raised from within sandbox's
+    // sighandler.
+    act.sa_flags = SA_SIGINFO | SA_ONSTACK | SA_NODEFER;
     act.sa_sigaction = lfi_linux_on_signal;
     sigemptyset(&act.sa_mask);
 
-    if (sigaction(SIGSEGV, &act, &oldact_sigsegv))
+    if (sigaction(SIGSEGV, &act, &engine->oldact_sigsegv))
         perror("sigaction");
-    if (oldact_sigsegv.sa_handler != SIG_DFL)
+    if (engine->oldact_sigsegv.sa_handler != SIG_DFL)
         LOG(engine, "warning: existing host handler for SIGSEGV is non-default and overwritten\n");
 
-    if (sigaction(SIGILL, &act, &oldact_sigill))
+    if (sigaction(SIGILL, &act, &engine->oldact_sigill))
         perror("sigaction");
-    if (oldact_sigill.sa_handler != SIG_DFL)
+    if (engine->oldact_sigill.sa_handler != SIG_DFL)
         LOG(engine, "warning: existing host handler for SIGILL is non-default and overwritten\n");
 
-    if (sigaction(SIGBUS, &act, &oldact_sigbus))
+    if (sigaction(SIGBUS, &act, &engine->oldact_sigbus))
         perror("sigaction");
-    if (oldact_sigill.sa_handler != SIG_DFL)
+    if (engine->oldact_sigbus.sa_handler != SIG_DFL)
         LOG(engine, "warning: existing host handler for SIGBUS is non-default and overwritten\n");
 }
+#endif
 
 EXPORT struct LFILinuxEngine *
 lfi_linux_new(struct LFIEngine *lfi_engine, struct LFILinuxOptions opts)
@@ -99,7 +116,9 @@ lfi_linux_new(struct LFIEngine *lfi_engine, struct LFILinuxOptions opts)
         .opts = opts,
     };
 
+#ifndef SYS_MINIMAL
     lfi_linux_register_sighandler(engine);
+#endif
 
     LOG(engine, "initialized LFI Linux engine");
 

--- a/linux/linux.h
+++ b/linux/linux.h
@@ -102,7 +102,41 @@ typedef int64_t linux_time_t;
 #define LINUX_CLONE_CHILD_SETTID   0x1000000
 #define LINUX_CLONE_IO             0x80000000UL
 
-#define LINUX_SIGCHLD              0x11
+#define LINUX_SIGHUP               1
+#define LINUX_SIGINT               2
+#define LINUX_SIGQUIT              3
+#define LINUX_SIGILL               4
+#define LINUX_SIGTRAP              5
+#define LINUX_SIGABRT              6
+#define LINUX_SIGBUS               7
+#define LINUX_SIGFPE               8
+#define LINUX_SIGKILL              9
+#define LINUX_SIGUSR1              10
+#define LINUX_SIGSEGV              11
+#define LINUX_SIGUSR2              12
+#define LINUX_SIGPIPE              13
+#define LINUX_SIGALRM              14
+#define LINUX_SIGTERM              15
+#define LINUX_SIGSTKFLT            16
+#define LINUX_SIGCHLD              17
+#define LINUX_SIGCONT              18
+#define LINUX_SIGSTOP              19
+#define LINUX_SIGTSTP              20
+#define LINUX_SIGTTIN              21
+#define LINUX_SIGTTOU              22
+#define LINUX_SIGURG               23
+#define LINUX_SIGXCPU              24
+#define LINUX_SIGXFSZ              25
+#define LINUX_SIGVTALRM            26
+#define LINUX_SIGPROF              27
+#define LINUX_SIGWINCH             28
+#define LINUX_SIGIO                29
+#define LINUX_SIGPWR               30
+#define LINUX_SIGSYS               31
+#define LINUX_NSIG                 32
+
+#define LINUX_SIG_DFL              0
+#define LINUX_SIG_IGN              1
 
 #define LINUX_PR_SET_NAME          15
 

--- a/linux/linux.h
+++ b/linux/linux.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <signal.h>
 #include "arch_types.h"
 #include "lfi_linux.h"
 #include "log.h"
@@ -9,6 +10,12 @@
 struct LFILinuxEngine {
     struct LFIEngine *engine;
     struct LFILinuxOptions opts;
+
+#ifndef SYS_MINIMAL
+    struct sigaction oldact_sigsegv;
+    struct sigaction oldact_sigill;
+    struct sigaction oldact_sigbus;
+#endif
 };
 
 struct Dirent {

--- a/linux/linux.h
+++ b/linux/linux.h
@@ -103,7 +103,41 @@ typedef int64_t linux_time_t;
 #define LINUX_CLONE_CHILD_SETTID   0x1000000
 #define LINUX_CLONE_IO             0x80000000UL
 
-#define LINUX_SIGCHLD              0x11
+#define LINUX_SIGHUP               1
+#define LINUX_SIGINT               2
+#define LINUX_SIGQUIT              3
+#define LINUX_SIGILL               4
+#define LINUX_SIGTRAP              5
+#define LINUX_SIGABRT              6
+#define LINUX_SIGBUS               7
+#define LINUX_SIGFPE               8
+#define LINUX_SIGKILL              9
+#define LINUX_SIGUSR1              10
+#define LINUX_SIGSEGV              11
+#define LINUX_SIGUSR2              12
+#define LINUX_SIGPIPE              13
+#define LINUX_SIGALRM              14
+#define LINUX_SIGTERM              15
+#define LINUX_SIGSTKFLT            16
+#define LINUX_SIGCHLD              17
+#define LINUX_SIGCONT              18
+#define LINUX_SIGSTOP              19
+#define LINUX_SIGTSTP              20
+#define LINUX_SIGTTIN              21
+#define LINUX_SIGTTOU              22
+#define LINUX_SIGURG               23
+#define LINUX_SIGXCPU              24
+#define LINUX_SIGXFSZ              25
+#define LINUX_SIGVTALRM            26
+#define LINUX_SIGPROF              27
+#define LINUX_SIGWINCH             28
+#define LINUX_SIGIO                29
+#define LINUX_SIGPWR               30
+#define LINUX_SIGSYS               31
+#define LINUX_NSIG                 32
+
+#define LINUX_SIG_DFL              0
+#define LINUX_SIG_IGN              1
 
 #define LINUX_PR_SET_NAME          15
 

--- a/linux/proc.c
+++ b/linux/proc.c
@@ -37,6 +37,7 @@ lfi_proc_new(struct LFILinuxEngine *engine)
     pthread_mutex_init(&proc->lk_threads, NULL);
     pthread_mutex_init(&proc->lk_box, NULL);
     pthread_mutex_init(&proc->lk_brk, NULL);
+    pthread_mutex_init(&proc->lk_signals, NULL);
     pthread_mutex_init(&proc->cwd.lk, NULL);
     pthread_cond_init(&proc->cond_threads, NULL);
 

--- a/linux/proc.h
+++ b/linux/proc.h
@@ -61,6 +61,11 @@ struct LibSymbols {
     lfiptr setjmp;
 };
 
+struct SigActionEntry {
+    bool valid;
+    struct SigAction entry;
+};
+
 struct LFILinuxProc {
     // Underlying sandbox information.
     struct LFIBox *box;
@@ -124,6 +129,9 @@ struct LFILinuxProc {
     pthread_mutex_t lk_proc;
 
     struct LFILinuxEngine *engine;
+
+    // Per-signal handler table.
+    struct SigActionEntry signals[LINUX_NSIG];
 };
 
 struct LFILinuxThread {

--- a/linux/proc.h
+++ b/linux/proc.h
@@ -144,6 +144,7 @@ struct LFILinuxProc {
 
     // Per-signal handler table.
     struct SigActionEntry signals[LINUX_NSIG];
+    pthread_mutex_t lk_signals;
 };
 
 struct LFILinuxThread {

--- a/linux/proc.h
+++ b/linux/proc.h
@@ -62,6 +62,11 @@ struct LibSymbols {
     lfiptr setjmp;
 };
 
+struct SigActionEntry {
+    bool valid;
+    struct SigAction entry;
+};
+
 struct LFILinuxProc {
     // Underlying sandbox information.
     struct LFIBox *box;
@@ -136,6 +141,9 @@ struct LFILinuxProc {
     pthread_mutex_t lk_proc;
 
     struct LFILinuxEngine *engine;
+
+    // Per-signal handler table.
+    struct SigActionEntry signals[LINUX_NSIG];
 };
 
 struct LFILinuxThread {

--- a/linux/sys.c
+++ b/linux/sys.c
@@ -103,11 +103,11 @@ syshandle(struct LFILinuxThread *t, uintptr_t sysno, uintptr_t a0, uintptr_t a1,
 
         // Signals (also needed, at least as stubs, for threads).
         SYS(rt_sigaction,
-                sys_ignore(t, "rt_sigaction"))
+                sys_rt_sigaction(t, a0, a1, a2, a3))
         SYS(rt_sigprocmask,
                 sys_ignore(t, "rt_sigprocmask"))
         SYS(rt_sigreturn,
-                sys_ignore(t, "rt_sigreturn"))
+                sys_rt_sigreturn(t))
         SYS(sigaltstack,
                 sys_ignore(t, "sigaltstack"))
 

--- a/linux/sys/meson.build
+++ b/linux/sys/meson.build
@@ -56,6 +56,7 @@ if not get_option('sys_minimal')
     'sys_truncate.c',
     'sys_unlinkat.c',
     'sys_uname.c',
+    'sys_signal.c',
     'sys_write.c',
     'sys_writev.c',
   )

--- a/linux/sys/sys.h
+++ b/linux/sys/sys.h
@@ -304,3 +304,10 @@ sys_dup(struct LFILinuxThread *t, int oldfd);
 
 int
 sys_dup3(struct LFILinuxThread *t, int oldfd, int newfd, int flags);
+
+int
+sys_rt_sigaction(struct LFILinuxThread *t, int sig, lfiptr actp, lfiptr oldp,
+    uint64_t sigsetsize);
+
+uintptr_t
+sys_rt_sigreturn(struct LFILinuxThread *t);

--- a/linux/sys/sys_signal.c
+++ b/linux/sys/sys_signal.c
@@ -1,0 +1,87 @@
+#include "sys/sys.h"
+
+#include <assert.h>
+#include <signal.h>
+#include <string.h>
+
+int
+sys_rt_sigaction(struct LFILinuxThread *t, int sig, lfiptr actp, lfiptr oldp,
+    uint64_t sigsetsize)
+{
+    if (sig < 1 || sig >= LINUX_NSIG)
+        return -LINUX_EINVAL;
+    if (sigsetsize != 8) {
+        LOG(t->proc->engine, "rt_sigaction (%d): sigsetsize != 8", sig);
+        return -LINUX_EINVAL;
+    }
+
+    // Write old action if requested.
+    if (oldp) {
+        void *ob = bufhost(t, oldp, sizeof(struct SigAction),
+            alignof(struct SigAction));
+        if (!ob)
+            return -LINUX_EFAULT;
+        struct SigAction *old = ob;
+        if (t->proc->signals[sig].valid) {
+            *old = t->proc->signals[sig].entry;
+        } else {
+            *old = (struct SigAction){ .handler = LINUX_SIG_DFL };
+        }
+    }
+
+    if (!actp)
+        return 0;
+
+    void *ab = bufhost(t, actp, sizeof(struct SigAction),
+        alignof(struct SigAction));
+    if (!ab)
+        return -LINUX_EFAULT;
+    struct SigAction *act = ab;
+
+    if (act->handler == LINUX_SIG_DFL || act->handler == LINUX_SIG_IGN) {
+        t->proc->signals[sig].valid = false;
+        return 0;
+    }
+
+    if ((act->flags & SA_RESTORER) == 0) {
+        LOG(t->proc->engine, "TODO: rt_sigaction must use SA_RESTORER");
+        return -LINUX_EINVAL;
+    }
+
+    if (!lfi_box_ptrvalid(t->proc->box, act->handler)) {
+        LOG(t->proc->engine, "rt_sigaction: handler is invalid!\n");
+        return -LINUX_EINVAL;
+    }
+    if ((act->handler & 0x1f) != 0) {
+        LOG(t->proc->engine, "rt_sigaction: handler is not bundle aligned!\n");
+        return -LINUX_EINVAL;
+    }
+
+    if (!lfi_box_ptrvalid(t->proc->box, act->restorer)) {
+        LOG(t->proc->engine, "rt_sigaction: restorer is invalid!\n");
+        return -LINUX_EINVAL;
+    }
+    // NOTE: upstream musl restorer is intentionally not aligned.
+    if ((act->restorer & 0x1f) != 0) {
+        LOG(t->proc->engine,
+            "rt_sigaction: restorer(%lx) is not bundle aligned!\n",
+            act->restorer);
+        return -LINUX_EINVAL;
+    }
+
+    t->proc->signals[sig].entry = *act;
+    t->proc->signals[sig].valid = true;
+
+    LOG(t->proc->engine, "rt_sigaction (%d): handler: %lx", sig, act->handler);
+    LOG(t->proc->engine, "sa_flags: %lx", act->flags);
+
+    return 0;
+}
+
+uintptr_t
+sys_rt_sigreturn(struct LFILinuxThread *t)
+{
+    LOG(t->proc->engine, "rt_sigreturn");
+    lfi_ctx_exit(t->ctx, 0);
+    __builtin_unreachable();
+}

--- a/linux/sys/sys_signal.c
+++ b/linux/sys/sys_signal.c
@@ -15,6 +15,7 @@ sys_rt_sigaction(struct LFILinuxThread *t, int sig, lfiptr actp, lfiptr oldp,
         return -LINUX_EINVAL;
     }
 
+    LOCK_WITH_DEFER(&t->proc->lk_signals, lk_signals);
     // Write old action if requested.
     if (oldp) {
         void *ob = bufhost(t, oldp, sizeof(struct SigAction),

--- a/linux/sys/sys_signal.c
+++ b/linux/sys/sys_signal.c
@@ -53,15 +53,18 @@ sys_rt_sigaction(struct LFILinuxThread *t, int sig, lfiptr actp, lfiptr oldp,
         LOG(t->proc->engine, "rt_sigaction: handler is invalid!\n");
         return -LINUX_EINVAL;
     }
+#if defined(__x86_64__)
     if ((act->handler & 0x1f) != 0) {
         LOG(t->proc->engine, "rt_sigaction: handler is not bundle aligned!\n");
         return -LINUX_EINVAL;
     }
+#endif
 
     if (!lfi_box_ptrvalid(t->proc->box, act->restorer)) {
         LOG(t->proc->engine, "rt_sigaction: restorer is invalid!\n");
         return -LINUX_EINVAL;
     }
+#if defined(__x86_64__)
     // NOTE: upstream musl restorer is intentionally not aligned.
     if ((act->restorer & 0x1f) != 0) {
         LOG(t->proc->engine,
@@ -69,11 +72,12 @@ sys_rt_sigaction(struct LFILinuxThread *t, int sig, lfiptr actp, lfiptr oldp,
             act->restorer);
         return -LINUX_EINVAL;
     }
+#endif
 
     t->proc->signals[sig].entry = *act;
     t->proc->signals[sig].valid = true;
 
-    LOG(t->proc->engine, "rt_sigaction (%d): handler: %lx", sig, act->handler);
+    LOG(t->proc->engine, "rt_sigaction (%d): handler: %lx, restorer: %lx", sig, act->handler, act->restorer);
     LOG(t->proc->engine, "sa_flags: %lx", act->flags);
 
     return 0;


### PR DESCRIPTION
With this feature, now lfi-runtime can support programs that install custom SIGSEGV/SIGILL/SIGBUS handler (e.g., JS runtime) on Linux x86_64 and arm64. Restoring FP regs is not supported.

This PR requires musl with [c28e53](https://github.com/zyedidia/musl/commit/c28e53cb3f69c66fb1ebae8751d9db998f30ff62)
Let me know if you think it is better to force align the unaligned restorer instead of emitting an error.