### PR TITLE
Fix TLS slot conflict with host stack canary on x86_64

### DIFF
--- a/core/arch_asm.h
+++ b/core/arch_asm.h
@@ -20,7 +20,7 @@
 // protector is only stored in this TLS slot to begin with on x86-64 and
 // Android-Arm64. On standard Arm64 the slot is unused because the stack
 // protector is global.
-#define TLS_SLOT_LFI 5
+#define TLS_SLOT_LFI 12
 
 #if defined(__aarch64__) || defined(_M_ARM64)
 


### PR DESCRIPTION
On x86_64 Linux, glibc uses `%fs:0x28` (slot 5) for the stack canary (stack_guard). LFI was also using `TLS_SLOT_LFI = 5` to store the sandbox context pointer (ctx), overwriting the host's stack canary.

In multi-threaded host environments (like the JVM), other threads (e.g., GC threads) may read or write to this slot. When the GC thread overwrites `%fs:0x28` back with the real stack canary while the sandbox is running, LFI subsequently reads the stack canary instead of the ctx pointer during sandbox exit or callback, causing a segmentation fault when dereferencing it.

Resolved this by changing `TLS_SLOT_LFI` to 12 , which is an unused slot outside the standard `tcbhead_t` structure but still within the safely allocated thread descriptor region. This avoids conflicts with the host stack canary and other glibc internals.