### PR TITLE
Add new header for new std::nothrow

### DIFF
--- a/core/mmap/mmap_c.cpp
+++ b/core/mmap/mmap_c.cpp
@@ -1,6 +1,8 @@
 #include "mmap_c.h"
 #include "addr_space.h"
 
+#include <new>
+
 struct MMapAddrSpace {
   mmap::AddrSpace impl;
 };


### PR DESCRIPTION
Libc++ removed certain transitive includes so we need to add new header for the file.

```
Error:
external/lfi/lfi-runtime/core/mmap/mmap_c.cpp:34:24: error: no member named 'nothrow' in namespace 'std'
   34 |   auto *mm = new (std::nothrow) MMapAddrSpace;
      |                        ^~~~~~~
1 error generated
```